### PR TITLE
{spotify-login} username replaced with spotify-login.

### DIFF
--- a/src/Components/Login/Login.js
+++ b/src/Components/Login/Login.js
@@ -1,0 +1,12 @@
+import React from "react";
+import Button from "react-bootstrap/Button";
+
+const Login = () => { 
+    return (
+<Button className="d-inline-block" variant="success" type="submit">
+    <a href="http://localhost:8888">Login first</a>
+  </Button>
+    )
+}
+
+export default Login;

--- a/src/Components/Result/Result.js
+++ b/src/Components/Result/Result.js
@@ -45,7 +45,7 @@ function Result(props) {
       </div>
       <div>
         <Button className="d-inline-block" variant="success" type="submit">
-          <a href="http://localhost:8888">Login first</a>
+          <a href="/playlist">Get your playlist of the day!</a>
         </Button>
         <Button
           className="d-inline-block"

--- a/src/Webpages/WelcomePage.js
+++ b/src/Webpages/WelcomePage.js
@@ -1,12 +1,12 @@
 import React from "react";
-import Username from "../Components/Username/Username";
+import Login from "../Components/Login/Login";
 import "./WelcomePage.css";
 
 const WelcomePage = () => {
   return (
     <div className="App-header">
       <h2>Find what playlist fits your feeling</h2>
-      <Username />
+      <Login />
     </div>
   );
 };


### PR DESCRIPTION
This replaces the <username> component with the <Login> component for <WelcomePage> However the <Username> component was not yet deleted. We could do this later during our last branches.

Note: the backend branch that was tested with this was called call-test-spotify-redirect, where the spotify redirect was changed from /playlist/ to /quiz/.

